### PR TITLE
Bump to 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "owasm-std"
-version = "0.12.2"
+version = "0.13.0"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Sergey Shulepov <s.pepyakin@gmail.com>", "Oasis Labs <info@oasislabs.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,12 @@ categories = ["no-std", "embedded"]
 exclude = [ "demo/*" ]
 
 [dependencies]
-fixed-hash = { version = "0.3.0-beta", default-features = false }
-uint = { version = "0.5.0-beta", default-features = false }
 byteorder = { version = "1", default-features = false }
+parity-hash = { version = "1", default-features = false }
 tiny-keccak = "1"
 
 [features]
-default = ["uint/common", "std"]
-std = ["fixed-hash/std", "uint/std", "byteorder/std"]
+default = []
+std = ["parity-hash/std"]
 test = ["std"]
 panic_with_msg = []

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Oasis WASM contracts standard library for Rust
 
-[Documentation](https://docs.rs/crate/owasm-std/)
+[Documentation](https://docs.rs/crate/owasm_std/)
 
 `owasm-std` is a limited subset of the Rust standard library, along with a custom allocator which delegates the allocation to the runtime-defined externs.
 
@@ -18,7 +18,7 @@ In the spirit of open-source, we intend to contribute bug fixes and new features
 Just add a dependency
 ```toml
 [dependencies]
-owasm-std = "0.12"
+owasm-std = "0.13"
 ```
 
 Test `owasm-std` with

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,5 +1,5 @@
 use tiny_keccak::Keccak;
-use types::H256;
+use hash::H256;
 
 /// Compute keccak hash.
 ///
@@ -8,24 +8,21 @@ use types::H256;
 /// ```rust
 /// use owasm_std::keccak;
 ///
-/// let hash = keccak("hello world".as_bytes());
+/// let hash = keccak("hello world");
 ///
-/// let expected = types::H256::from([
+/// let expected = &[
 /// 	71, 23, 50, 133, 168, 215, 52, 30,
 /// 	94, 151, 47, 198, 119, 40, 99, 132,
 /// 	248, 2, 248, 239, 66, 165, 236, 95,
 /// 	3, 187, 250, 37, 76, 176, 31, 173
-/// ]);
+/// ];
 ///
-/// assert_eq!(hash, expected);
+/// assert_eq!(hash.as_ref(), expected);
 /// ```
-pub fn keccak<T>(input: T) -> H256
-where
-	T: AsRef<[u8]>
-{
+pub fn keccak<T>(input: T) -> H256 where T: AsRef<[u8]> {
 	let mut keccak = Keccak::new_keccak256();
-	let mut res = H256::zero();
+	let mut res = H256::new();
 	keccak.update(input.as_ref());
-	keccak.finalize(res.as_bytes_mut());
+	keccak.finalize(&mut res);
 	res
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,15 +14,22 @@ extern crate core;
 
 extern crate byteorder;
 
+#[allow(unused)]
 #[macro_use]
-extern crate fixed_hash;
+extern crate alloc;
+pub use alloc::{vec, format};
 
-extern crate uint;
-
+pub extern crate parity_hash;
 extern crate tiny_keccak;
 
 use byteorder::{LittleEndian, ByteOrder};
 
+pub use parity_hash as hash;
+
+pub use alloc::boxed::Box;
+pub use alloc::string::String;
+pub use alloc::str;
+pub use alloc::vec::Vec;
 pub use parity_hash as hash;
 
 // Safe wrapper around debug logging

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
 #![feature(lang_items)]
 #![feature(link_args)]
+#![feature(alloc)]
 #![feature(core_intrinsics)]
 #![feature(panic_info_message)]
 
@@ -23,8 +24,6 @@ pub extern crate parity_hash;
 extern crate tiny_keccak;
 
 use byteorder::{LittleEndian, ByteOrder};
-
-pub use parity_hash as hash;
 
 pub use alloc::boxed::Box;
 pub use alloc::string::String;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ extern crate tiny_keccak;
 
 use byteorder::{LittleEndian, ByteOrder};
 
-pub mod types;
+pub use parity_hash as hash;
 
 // Safe wrapper around debug logging
 pub mod logger;

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -8,7 +8,7 @@ extern "C" {
 #[cfg(not(feature = "panic_with_msg"))]
 #[no_mangle]
 #[panic_handler]
-pub fn panic_fmt(_info: &crate::core::panic::PanicInfo) -> ! {
+pub fn panic_fmt(_info: &::core::panic::PanicInfo) -> ! {
 	unsafe {
 		panic(crate::core::ptr::null(), 0u32);
 	}
@@ -18,8 +18,8 @@ pub fn panic_fmt(_info: &crate::core::panic::PanicInfo) -> ! {
 #[cfg(feature = "panic_with_msg")]
 #[no_mangle]
 #[panic_handler]
-pub fn panic_fmt(info: &crate::core::panic::PanicInfo) -> ! {
-	use crate::Vec;
+pub fn panic_fmt(info: &::core::panic::PanicInfo) -> ! {
+	use Vec;
 	use byteorder::{LittleEndian, ByteOrder};
 
 	struct Sink {

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -8,7 +8,7 @@ extern "C" {
 #[cfg(not(feature = "panic_with_msg"))]
 #[no_mangle]
 #[panic_handler]
-pub fn panic_fmt(_info: &::core::panic::PanicInfo) -> ! {
+pub fn panic_fmt(_info: &crate::core::panic::PanicInfo) -> ! {
 	unsafe {
 		panic(crate::core::ptr::null(), 0u32);
 	}
@@ -18,8 +18,8 @@ pub fn panic_fmt(_info: &::core::panic::PanicInfo) -> ! {
 #[cfg(feature = "panic_with_msg")]
 #[no_mangle]
 #[panic_handler]
-pub fn panic_fmt(info: &::core::panic::PanicInfo) -> ! {
-	use Vec;
+pub fn panic_fmt(info: &crate::core::panic::PanicInfo) -> ! {
+	use crate::Vec;
 	use byteorder::{LittleEndian, ByteOrder};
 
 	struct Sink {


### PR DESCRIPTION
Removes `wee_alloc` to allow docs.rs to build, and removes `fixed_hash` dependency to allow crates to build with the `wasm32-unknown-unknown` target. Changes were made on top of version 0.10.0. 